### PR TITLE
DEV-3705 Don't need to add + to WhatsApp numbers

### DIFF
--- a/lib/smess/outputs/twilio_whatsapp.rb
+++ b/lib/smess/outputs/twilio_whatsapp.rb
@@ -6,11 +6,11 @@ module Smess
     private
 
     def to
-      "whatsapp:+#{sms.to}"
+      "whatsapp:#{sms.to}"
     end
 
     def sender
-      {from: "whatsapp:+#{from}"}
+      {from: "whatsapp:#{from}"}
     end
 
   end


### PR DESCRIPTION
[DEV-3705](https://trice.atlassian.net/browse/DEV-3705)

The WhatsApp API does not require a `+` prefixed to the phone number. I have tested it, it works fine without. The `+` is added by Twilio/WhatsApp automatically. Considering we're trying to store all phone numbers in a standard format, which includes the `+` prefix already, let's remove the Smess logic appending the `+` to any passed in phone number. In our case, this causes:

```
 Unable to create record\nThe 'To' number whatsapp:++18053001234 is not a valid phone number
 ```

[DEV-3705]: https://trice.atlassian.net/browse/DEV-3705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ