### PR TITLE
Update twilio-ruby dependency to 7.x

### DIFF
--- a/smess.gemspec
+++ b/smess.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'dotenv'
   s.add_dependency 'httpi', '>=4', '~> 4.0'
   s.add_dependency 'clickatell', '~> 0'
-  s.add_dependency 'twilio-ruby', '~> 6.2'
+  s.add_dependency 'twilio-ruby', '~> 7.10'
   s.add_dependency 'activesupport', '>= 5.2.6', '< 9.0.0'
 
   s.files = Dir["{lib}/**/*", "[A-Z]*", "init.rb"].reject { |f| f.match(%r{^(test|spec|features)/}) || f.end_with?('.gem') }


### PR DESCRIPTION
With the upgrade comes support for version 3.x of the `jwt` gem: https://github.com/twilio/twilio-ruby/pull/753

Previously, the `smess -> twilio-ruby -> jwt 2.x` dependency chain prevented `tricefy4` (and any of its dependencies) from using `jwt >= 3.x`.

The gem's Upgrade Guide does not call out any particular breaking changes: https://github.com/twilio/twilio-ruby/blob/main/UPGRADE.md#2024-01-19-6xx-to-7xx